### PR TITLE
Bug fix - replace `id2name` with `to_s`

### DIFF
--- a/mrblib/ostruct.rb
+++ b/mrblib/ostruct.rb
@@ -85,7 +85,7 @@ class OpenStruct
   protected :table
 
   def method_missing mid, *args
-    mname = mid.id2name
+    mname = mid.to_s
     len = args.length
     if mname.chomp! '='
       if len != 1


### PR DESCRIPTION
See: https://github.com/mruby/mruby/commit/0c8cd60097bd1270ba86e84b2a5b18dd8992efd1

Original error:
```
mirb - Embeddable Interactive Ruby Shell

> o = OpenStruct.new
 => #<OpenStruct>
> o.foo = 1
undefined method 'id2name' (NoMethodError)
```